### PR TITLE
Pin Ghost to latest major version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # see versions at https://hub.docker.com/_/ghost
-FROM ghost:3.2.0
+FROM ghost:3
 
 WORKDIR $GHOST_INSTALL
 COPY . .


### PR DESCRIPTION
If you'd like to pin Ghost to a minor version, please fork this repo and update the `FROM` line in your fork.