### PR TITLE
Adds the repo URL parameter of the address of the one-click deploy to Render button

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,6 @@ This is a template repository for running [Ghost](https://ghost.org) on Render.
 
 ## Deployment
 
-[![Deploy to Render](https://render.com/images/deploy-to-render-button.svg)](https://render.com/deploy)
+[![Deploy to Render](https://render.com/images/deploy-to-render-button.svg)](https://render.com/deploy?repo=https://github.com/render-examples/ghost)
 
 See https://render.com/docs/deploy-ghost.


### PR DESCRIPTION
This is done so as to be able to determine the referrer on the resulting Render deploy page.

Signed-off-by: zach wick <zach@render.com>