### PR TITLE
Connect Ghost to MySQL using env vars

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -26,7 +26,13 @@ services:
 - type: pserv
   name: ghost-mysql
   repo: https://github.com/render-examples/mysql
+  plan: standard
+  env: docker
   autoDeploy: false
+  disk:
+    name: mysql
+    mountPath: /var/lib/mysql
+    sizeGB: 10
   envVars:
   - fromGroup: ghost-group
 

--- a/render.yaml
+++ b/render.yaml
@@ -6,22 +6,32 @@ services:
   disk:
     name: ghost
     mountPath: /var/lib/ghost/content
-    sizeGB: 10 #Feel free to change this to suit your needs.
+    sizeGB: 10
   envVars:
     - key: database__client
-      value: mysql # Replace with 'sqlite'
+      value: mysql # Can be replaced with 'sqlite'
     - key: database__connection__host
       fromService:
         name: ghost-mysql
         type: pserv
         property: host
     - key: database__connection__port
+      value: 3306
+    - key: database__connection__database
       fromService:
         name: ghost-mysql
         type: pserv
-        property: port
-    - key: database__connection__port
-      value: 3306
+        property: MYSQL_DATABASE
+    - key: database__connection__user
+      fromService:
+        name: ghost-mysql
+        type: pserv
+        property: MYSQL_USER
+    - key: database__connection__password
+      fromService:
+        name: ghost-mysql
+        type: pserv
+        property: MYSQL_PASSWORD
 
 - type: pserv
   name: ghost-mysql

--- a/render.yaml
+++ b/render.yaml
@@ -7,3 +7,37 @@ services:
     name: ghost
     mountPath: /var/lib/ghost/content
     sizeGB: 10 #Feel free to change this to suit your needs.
+  envVars:
+    - key: database__client
+      value: mysql # Replace with 'sqlite'
+    - key: database__connection__host
+      fromService:
+        name: ghost-mysql
+        type: pserv
+        property: host
+    - key: database__connection__port
+      fromService:
+        name: ghost-mysql
+        type: pserv
+        property: port
+    - key: database__connection__port
+      value: 3306
+
+- type: pserv
+  name: ghost-mysql
+  repo: https://github.com/render-examples/mysql
+  autoDeploy: false
+  envVars:
+  - fromGroup: ghost-group
+
+envVarGroups:
+- name: ghost-group
+  envVars:
+  - key: MYSQL_DATABASE
+    value: ghost
+  - key: MYSQL_USER
+    value: ghost-db-user
+  - key: MYSQL_PASSWORD
+    generateValue: true
+  - key: MYSQL_ROOT_PASSWORD
+    generateValue: true

--- a/render.yaml
+++ b/render.yaml
@@ -44,11 +44,6 @@ services:
     mountPath: /var/lib/mysql
     sizeGB: 10
   envVars:
-  - fromGroup: ghost-group
-
-envVarGroups:
-- name: ghost-group
-  envVars:
   - key: MYSQL_DATABASE
     value: ghost
   - key: MYSQL_USER

--- a/render.yaml
+++ b/render.yaml
@@ -21,17 +21,17 @@ services:
       fromService:
         name: ghost-mysql
         type: pserv
-        property: MYSQL_DATABASE
+        envVarKey: MYSQL_DATABASE
     - key: database__connection__user
       fromService:
         name: ghost-mysql
         type: pserv
-        property: MYSQL_USER
+        envVarKey: MYSQL_USER
     - key: database__connection__password
       fromService:
         name: ghost-mysql
         type: pserv
-        property: MYSQL_PASSWORD
+        envVarKey: MYSQL_PASSWORD
 
 - type: pserv
   name: ghost-mysql

--- a/render.yaml
+++ b/render.yaml
@@ -36,7 +36,7 @@ services:
 - type: pserv
   name: ghost-mysql
   repo: https://github.com/render-examples/mysql
-  plan: standard
+  plan: starter
   env: docker
   autoDeploy: false
   disk:


### PR DESCRIPTION
This is an attempt at making a template for a one-click deployment of Ghost on Render.

I'm still new to `render.yaml` so it's not perfect. For instance I tried using environment groups at first, but the syncs failed. 

This simpler version works, only issue is that Ghost reports migration lock issues on first run. 
So I have to shell into the MySQL instance, drop the `migration` and `migration_lock` tables, redeploy and then it works.

I'm hoping someone else can look at this and maybe improve it further.