### PR TITLE
Updates for Ghost 5 in order to use MySQL 8 as the backing database

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,4 @@ This is a template repository for running [Ghost](https://ghost.org) on Render.
 
 ## Deployment
 
-[![Deploy to Render](https://render.com/images/deploy-to-render-button.svg)](https://render.com/deploy?repo=https://github.com/render-examples/ghost)
-
 See https://render.com/docs/deploy-ghost.

--- a/render.yaml
+++ b/render.yaml
@@ -7,3 +7,36 @@ services:
     name: ghost
     mountPath: /var/lib/ghost/content
     sizeGB: 10 #Feel free to change this to suit your needs.
+  envVars:
+    - key: database__client
+      value: mysql
+    - key: database__connection__host
+      fromService:
+        type: pserv
+        name: mysql
+        property: host
+    - key: database__connection__database
+      value: ghostdb
+    - key: database__connection__user
+      value: mysql
+
+- type: pserv
+  name: mysql
+  plan: standard
+  env: docker
+  repo: https://github.com/render-examples/mysql
+  autoDeploy: false
+  disk:
+    name: mysql
+    mountPath: /var/lib/mysql
+    sizeGB: 10
+  envVars:
+    - key: MYSQL_DATABASE
+      value: ghostdb
+    - key: MYSQL_USER
+      value: mysql
+    - key: MYSQL_PASSWORD
+      generateValue: true
+    - key: MYSQL_ROOT_PASSWORD
+      generateValue: true
+


### PR DESCRIPTION
This PR also removes the "Deploy to Render" button since a successful initial deploy is required of the MySQL Private Service before the Ghost 5 Web Service can be brought up successfully when using MySQL as the backing database.

See https://render.com/docs/deploy-ghost for a deployment guide.

Signed-off-by: zach wick <zach@render.com>