### PR TITLE
Populate mysql password from mysql service

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -19,6 +19,10 @@ services:
       value: ghostdb
     - key: database__connection__user
       value: mysql
+    - key: database__connection__password
+      fromService:
+        type: pserv
+        envVarKey: MYSQL_PASSWORD
 
 - type: pserv
   name: mysql

--- a/render.yaml
+++ b/render.yaml
@@ -22,6 +22,7 @@ services:
     - key: database__connection__password
       fromService:
         type: pserv
+        name: mysql
         envVarKey: MYSQL_PASSWORD
 
 - type: pserv


### PR DESCRIPTION
This PR uses the render.yaml `envVarKey` to grab the MYSQL_PASSWORD from the MySQL instance and use it in the websevice so a manual copy of the var doesn't need to be performed.