### PR TITLE
Minor version bump

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # see versions at https://hub.docker.com/_/ghost
-FROM ghost:5.14.1
+FROM ghost:5.42.0
 
 WORKDIR $GHOST_INSTALL
 COPY . .


### PR DESCRIPTION
This upgrade addresses https://github.com/TryGhost/Ghost/security/advisories/GHSA-9gh8-wp53-ccc6 in the example.

Smoke tested here: https://ghost-fmxt.onrender.com/