### PR TITLE
feat: Update ghost version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # see versions at https://hub.docker.com/_/ghost
-FROM ghost:5.14.1
+FROM ghost:5.75.2
 
 WORKDIR $GHOST_INSTALL
 COPY . .


### PR DESCRIPTION
Security: 
Ghost version should be >= `5.22.7`
ie. https://github.com/TryGhost/Ghost/security/advisories/GHSA-9gh8-wp53-ccc6

Update docker version to latest `5.75.2`